### PR TITLE
Support for building on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Puppeteer-based web page renderer backend for FitLayout. It uses [puppeteer](htt
 
 ## Requirements
 
-`Node.js` version 14 or greater and `npm` version 6 or later are required for installing the package.
+`Node.js` version 14 or greater and `npm` version 6 or later are required for installing the package. For Windows, WSL is required.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "install": "sh build.sh",
+    "install": "bash build.sh",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
If the `sh` command is replaced with `bash` command and git is instructed to use LF in *.sh files, the build will work on Windows with WSL installed as well.